### PR TITLE
add helper script to convert a human readable file size to byte

### DIFF
--- a/actions/Humanreadable_size_to_byte.bun.ts
+++ b/actions/Humanreadable_size_to_byte.bun.ts
@@ -4,19 +4,9 @@
  * License: MIT
  */
 import * as wmill from "windmill-client";
-import createClient, { type Middleware } from "openapi-fetch";
-
-type Nextcloud = {
-  baseUrl: string,
-  password: string,
-  username: string
-};
 
 export async function main(
-  ncResource: Nextcloud,
-  userId: string | null = null,
   HumanReadableSize: number,
-  useAppApiAuth: boolean = false,
 ) {
 
 var validAmount  = function(n) {

--- a/actions/Humanreadable_size_to_byte.bun.ts
+++ b/actions/Humanreadable_size_to_byte.bun.ts
@@ -1,0 +1,93 @@
+/*
+ * filesize-parser
+ * Copyright: Patrick Kettner
+ * License: MIT
+ */
+import * as wmill from "windmill-client";
+import createClient, { type Middleware } from "openapi-fetch";
+
+type Nextcloud = {
+  baseUrl: string,
+  password: string,
+  username: string
+};
+
+export async function main(
+  ncResource: Nextcloud,
+  userId: string | null = null,
+  HumanReadableSize: number,
+  useAppApiAuth: boolean = false,
+) {
+
+var validAmount  = function(n) {
+  return !isNaN(parseFloat(n)) && isFinite(n);
+};
+
+var parsableUnit = function(u) {
+  return u.match(/\D*/).pop() === u;
+};
+
+var incrementBases = {
+  2: [
+    [["b", "bit", "bits"], 1/8],
+    [["B", "Byte", "Bytes", "bytes"], 1],
+    [["Kb"], 128],
+    [["k", "K", "kb", "kB", "KB", "KiB", "Ki", "ki"], 1024],
+    [["Mb"], 131072],
+    [["m", "M", "mb", "mB", "MB", "MiB", "Mi", "mi"], Math.pow(1024, 2)],
+    [["Gb"], 1.342e+8],
+    [["g", "G", "gb", "gB", "GB", "GiB", "Gi", "gi"], Math.pow(1024, 3)],
+    [["Tb"], 1.374e+11],
+    [["t", "T", "tb", "tB", "TB", "TiB", "Ti", "ti"], Math.pow(1024, 4)],
+    [["Pb"], 1.407e+14],
+    [["p", "P", "pb", "pB", "PB", "PiB", "Pi", "pi"], Math.pow(1024, 5)],
+    [["Eb"], 1.441e+17],
+    [["e", "E", "eb", "eB", "EB", "EiB", "Ei", "ei"], Math.pow(1024, 6)]
+  ],
+  10: [
+    [["b", "bit", "bits"], 1/8],
+    [["B", "Byte", "Bytes", "bytes"], 1],
+    [["Kb"], 125],
+    [["k", "K", "kb", "kB", "KB", "KiB", "Ki", "ki"], 1000],
+    [["Mb"], 125000],
+    [["m", "M", "mb", "mB", "MB", "MiB", "Mi", "mi"], 1.0e+6],
+    [["Gb"], 1.25e+8],
+    [["g", "G", "gb", "gB", "GB", "GiB", "Gi", "gi"], 1.0e+9],
+    [["Tb"], 1.25e+11],
+    [["t", "T", "tb", "tB", "TB", "TiB", "Ti", "ti"], 1.0e+12],
+    [["Pb"], 1.25e+14],
+    [["p", "P", "pb", "pB", "PB", "PiB", "Pi", "pi"], 1.0e+15],
+    [["Eb"], 1.25e+17],
+    [["e", "E", "eb", "eB", "EB", "EiB", "Ei", "ei"], 1.0e+18]
+  ]
+};
+
+
+  var options = arguments[1] || {};
+  var base = parseInt(options.base || 2);
+
+  var parsed = HumanReadableSize.toString().match(/^([0-9\.,]*)(?:\s*)?(.*)$/);
+  var amount = parsed[1].replace(',','.');
+  var unit = parsed[2];
+
+  var validUnit = function(sourceUnit) {
+    return sourceUnit === unit;
+  };
+
+  if (!validAmount(amount) || !parsableUnit(unit)) {
+    throw 'Can\'t interpret ' + (HumanReadableSize || 'a blank string');
+  }
+  if (unit === '') return Math.round(Number(amount));
+
+  var increments = incrementBases[base];
+  for (var i = 0; i < increments.length; i++) {
+    var _increment = increments[i];
+
+    if (_increment[0].some(validUnit)) {
+      return Math.round(amount * _increment[1]);
+    }
+  }
+
+  throw unit + ' doesn\'t appear to be a valid unit';
+
+}


### PR DESCRIPTION
Helper script to convert a human readable file size to byte. Can be used for example to set the quota for a group folder and allow the user to provide the value in a nice human readable format.

I thought it could be quite useful to have such a script for everyone ready to use.